### PR TITLE
change systemd startup order to occur with network

### DIFF
--- a/assets/vpncloud@.service
+++ b/assets/vpncloud@.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=VpnCloud network '%I'
-Before=systemd-user-sessions.service
+Before=network.target
 
 [Service]
 Type=forking

--- a/assets/vpncloud@.service
+++ b/assets/vpncloud@.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=VpnCloud network '%I'
-Before=network.target
+Before=network-online.target
 
 [Service]
 Type=forking


### PR DESCRIPTION
For services which depend on binding to the VPN IP, startup order can matter. This changes the startup order to trigger with networking, allowing services waiting on network up to start successfully.