### PR TITLE
Fix wrong service control command in wizard message

### DIFF
--- a/src/wizard.rs
+++ b/src/wizard.rs
@@ -501,8 +501,8 @@ pub fn configure(name: Option<String>) -> Result<(), io::Error> {
         println!("  start the VPN:   sudo service vpncloud@{0} start", name);
         println!("  stop the VPN:    sudo service vpncloud@{0} stop", name);
         println!("  get the status:  sudo service vpncloud@{0} status", name);
-        println!("  add VPN to autostart:       sudo sysctl enable vpncloud@{0}", name);
-        println!("  remove VPN from autostart:  sudo sysctl disable vpncloud@{0}", name);
+        println!("  add VPN to autostart:       sudo systemctl enable vpncloud@{0}", name);
+        println!("  remove VPN from autostart:  sudo systemctl disable vpncloud@{0}", name);
     }
 
     Ok(())


### PR DESCRIPTION
This a minor typo of no real importance.

The command should refer to [systemctl](https://man7.org/linux/man-pages//man1/systemctl.1.html) instead of [sysctl](https://linux.die.net/man/8/sysctl) (the utility to change kernel tunables at run time).

If you would like to see another commit message, it would be quicker for you to reject this and fix it manually.

Love the project. Cheers.