### PR TITLE
Create armel build targets for cross compilation

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -18,6 +18,16 @@ linker = "arm-linux-gnueabihf-gcc"
 objcopy = { path = "arm-linux-gnueabihf-objcopy" }
 strip = { path = "arm-linux-gnueabihf-strip" }
 
+[target.armv5te-unknown-linux-gnueabi]
+linker = "arm-linux-gnueabi-gcc"
+objcopy = { path = "arm-linux-gnueabi-objcopy" }
+strip = { path = "arm-linux-gnueabi-strip" }
+
+[target.armv5te-unknown-linux-musleabi]
+linker = "arm-linux-gnueabi-gcc"
+objcopy = { path = "arm-linux-gnueabi-objcopy" }
+strip = { path = "arm-linux-gnueabi-strip" }
+
 [target.aarch64-unknown-linux-gnu]
 linker = "aarch64-linux-gnu-gcc"
 objcopy = { path = "aarch64-linux-gnu-objcopy" }

--- a/builder/Dockerfile-deb
+++ b/builder/Dockerfile-deb
@@ -9,8 +9,10 @@ RUN apt-get update \
     curl \
     gcc-aarch64-linux-gnu \
     gcc-arm-linux-gnueabihf \
+    gcc-arm-linux-gnueabi \
     libc6-dev-arm64-cross \
     libc6-dev-armhf-cross \
+    libc6-dev-armel-cross \
     libc6-dev-i386 \
     gcc-5-multilib \
     asciidoctor \
@@ -22,6 +24,7 @@ ENV RUSTUP_HOME=/opt/rust/rustup \
 RUN curl https://sh.rustup.rs -sSf | env CARGO_HOME=/opt/rust/cargo sh -s -- -y --default-toolchain ${TOOLCHAIN} --profile minimal --no-modify-path
 
 RUN env CARGO_HOME=/opt/rust/cargo rustup target add i686-unknown-linux-gnu \
+ && env CARGO_HOME=/opt/rust/cargo rustup target add armv5te-unknown-linux-gnueabi \
  && env CARGO_HOME=/opt/rust/cargo rustup target add armv7-unknown-linux-gnueabihf \
  && env CARGO_HOME=/opt/rust/cargo rustup target add aarch64-unknown-linux-gnu
 

--- a/builder/Dockerfile-musl
+++ b/builder/Dockerfile-musl
@@ -9,8 +9,10 @@ RUN apt-get update \
     curl \
     gcc-aarch64-linux-gnu \
     gcc-arm-linux-gnueabihf \
+    gcc-arm-linux-gnueabi \
     libc6-dev-arm64-cross \
     libc6-dev-armhf-cross \
+    libc6-dev-armel-cross \
     libc6-dev-i386 \
     gcc-5-multilib \
     asciidoctor \
@@ -24,6 +26,7 @@ RUN curl https://sh.rustup.rs -sSf | env CARGO_HOME=/opt/rust/cargo sh -s -- -y 
 
 RUN env CARGO_HOME=/opt/rust/cargo rustup target add x86_64-unknown-linux-musl \
  && env CARGO_HOME=/opt/rust/cargo rustup target add i686-unknown-linux-musl \
+ && env CARGO_HOME=/opt/rust/cargo rustup target add armv5te-unknown-linux-musleabi \
  && env CARGO_HOME=/opt/rust/cargo rustup target add armv7-unknown-linux-musleabihf \
  && env CARGO_HOME=/opt/rust/cargo rustup target add aarch64-unknown-linux-musl
 

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -53,6 +53,7 @@ build_deb() {
 
 build_deb i386 i686-unknown-linux-gnu
 build_deb armhf armv7-unknown-linux-gnueabihf
+build_deb armel armv5te-unknown-linux-gnueabi
 build_deb arm64 aarch64-unknown-linux-gnu
 
 
@@ -69,6 +70,7 @@ build_static() {
 
 build_static amd64 x86_64-unknown-linux-musl
 #build_static i386 i686-unknown-linux-musl
+build_static armel armv5te-unknown-linux-musleabi
 build_static armhf armv7-unknown-linux-musleabihf
 build_static arm64 aarch64-unknown-linux-musl
 


### PR DESCRIPTION
This adds armv5te-unknown-linux-gnueabi and armv5te-unknown-linux-musleabi
targets in the builder/build.sh script.
